### PR TITLE
Remove rename since gulp.dest will copy files on its own

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,8 +6,6 @@
 
 var gulp = require('gulp');
 var svgSprite = require('gulp-svg-sprite');
-var rename = require('gulp-rename');
-
 // SVG Config
 var config = {
   mode: {
@@ -28,7 +26,6 @@ gulp.task('sprite-page', function() {
 
 gulp.task('sprite-shortcut', function() {
   return gulp.src('sprite/sprite.svg')
-    .pipe(rename('sprite.svg'))
     .pipe(gulp.dest('.'));
 });
 


### PR DESCRIPTION
Hi,
After reading your awesome article, I checked out the boilerplate project you put together. I was planning on using it for a small project and noticed you were using gulp-rename to move the sprite.svg around. But, the gulp.dest function will actually do this for free. I tested the workflow without the rename and it seems to work fine. Anyway, let me know what you think Keep up the awesome work!
-Paul
