### PR TITLE
Add gulp to scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A boilerplate icon system implementing SVG sprites and external use pattern",
   "main": "sprite.svg",
   "scripts": {
+    "gulp": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
This will enable `gulp` to be run with the locally installed version instead of relying on a globally installed one.

Can be run with `$ npm run gulp`.
